### PR TITLE
fix: fix crash when calling attr on empty collection

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,9 @@
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
+        <testsuite name="Regressions">
+            <directory suffix="Test.php">./tests/Regressions</directory>
+        </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">
         <include>

--- a/src/Contracts/DomCollectionInterface.php
+++ b/src/Contracts/DomCollectionInterface.php
@@ -34,9 +34,9 @@ interface DomCollectionInterface extends DomInterface
     public function each(callable $callback);
 
     /**
-     * @return DomInterface
+     * @return DomInterface|null
      */
-    public function first(): DomInterface;
+    public function first(): ?DomInterface;
 
     /**
      * @return Collection

--- a/src/DomCollection.php
+++ b/src/DomCollection.php
@@ -68,9 +68,9 @@ class DomCollection implements DomCollectionInterface, ArrayAccess, IteratorAggr
     }
 
     /**
-     * @return DomInterface
+     * @return ?DomInterface
      */
-    public function first(): DomInterface
+    public function first(): ?DomInterface
     {
         return $this
             ->elements
@@ -296,12 +296,18 @@ class DomCollection implements DomCollectionInterface, ArrayAccess, IteratorAggr
      * @param string $name
      * @param null   $value
      *
-     * @return $this|string
+     * @return $this|string|null
      */
     public function attr(string $name, $value = null)
     {
         if ($value === null) {
-            return $this->first()->attr($name);
+            $first = $this->first();
+
+            if ($first) {
+                return $first->attr($name);
+            }
+
+            return null;
         }
 
         foreach ($this->elements as $element) {

--- a/tests/Regressions/AttrTest.php
+++ b/tests/Regressions/AttrTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Zae\DOM\Tests\Regressions;
+
+use Zae\DOM\DomElement;
+use Zae\DOM\Tests\TestCase;
+
+/**
+ * Class AttrTest
+ * @package Zae\DOM\Tests\Regressions
+ */
+class AttrTest extends TestCase
+{
+    const html1 = '<div class="parent"></div>';
+
+    /**
+     * @test
+     * @group collection
+     */
+    public function it_can_handle_attr_on_empty_collection(): void
+    {
+        $doc = new DomElement();
+        $doc->loadString(static::html1);
+
+        $emptycollection = $doc->find('.notexists');
+
+        $emptycollection->attr('foo');
+
+        static::assertTrue(true);
+    }
+}


### PR DESCRIPTION
Don't crash with the error `TypeError: Return value of Zae\DOM\DomCollection::first() must
implement interface Zae\DOM\Contracts\DomInterface, null returned` when calling attr
on an empty collection.

Also add a regression testsuite with the first test this bug.

Fixes #3 