### PR TITLE
Run the tests using the lowest and the highest version of dependencies

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -55,6 +55,7 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest]
         php-version: ['7.2', '7.3', '7.4']
+        dependency-version: [ prefer-lowest, prefer-stable ]
 
     steps:
       - uses: actions/checkout@v2
@@ -78,7 +79,7 @@ jobs:
         run: composer validate
 
       - name: Install dependencies
-        run: composer install --no-interaction --no-suggest
+        run: composer update --no-interaction --no-suggest --${{ matrix.dependency-version }}
 
       - name: Run test suite
         run: composer run test-coverage

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "mockery/mockery": "^1.3",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/phpstan": "^1.4",
-        "phpunit/phpunit": "^8.0.0 | ^9.0.0",
+        "phpunit/phpunit": "^8.4.0 | ^9.0.0",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.6",
         "vimeo/psalm": "^4.19"


### PR DESCRIPTION
This way we know when we use some features of libraries we use that did not exists yet in the lowest versions we say we need in composer.json